### PR TITLE
clang-tidy suggestions :)

### DIFF
--- a/examples/list_all.cc
+++ b/examples/list_all.cc
@@ -1,12 +1,11 @@
-
 #include "netifaces/netifaces.hpp"
 #include <iostream>
 
 int main(int argc, char** argv) {
-    auto interfaces = netifaces::interfaces();
-    for (auto& interface : interfaces) {
-        std::cout << interface->name() << std::endl;
-        for (const auto addr : interface->addrs()) {
+    const auto& interfaces = netifaces::interfaces();
+    for (const auto& interface : interfaces) {
+        std::cout << interface.name() << std::endl;
+        for (const auto& addr : interface.addrs()) {
             std::cout << " " << addr.proto() << " " << addr.str() << std::endl;
         }
     }

--- a/include/netifaces/basic_types.hpp
+++ b/include/netifaces/basic_types.hpp
@@ -2,10 +2,8 @@
 #ifndef NETIFACES_BASIC_TYPES_HPP
 #define NETIFACES_BASIC_TYPES_HPP
 
-#include <unordered_map>
-#include <set>
+#include <string>
 #include <vector>
-#include <memory>
 
 namespace netifaces {
     enum class NetworkProto {
@@ -16,14 +14,14 @@ namespace netifaces {
         std::string str_;
         NetworkProto proto_;
     public:
-        NetworkAddress(NetworkProto proto, std::string str) 
+        NetworkAddress(NetworkProto proto, const std::string& str)
             : proto_(proto), str_(str) {}
 
         NetworkProto proto() const {
             return proto_;
         }
 
-        std::string str() const {
+        const std::string& str() const {
             return str_;
         }
     };
@@ -36,20 +34,23 @@ namespace netifaces {
             return addrs_;
         }
 
-        friend class NetworkInterfaceProvider;
     public:
-        NetworkInterface(std::string name) : name_(name), addrs_() {}
+        NetworkInterface(const std::string& name) : name_(name) {}
 
-        std::string name() const {
+        const std::string& name() const {
             return name_;
         }
 
-        const std::vector<NetworkAddress> addrs() const {
+        const std::vector<NetworkAddress>& addrs() const {
             return addrs_;
+        }
+
+        void add(NetworkAddress&& address) {
+            addrs_.push_back(std::move(address));
         }
     };
 
-    using NetworkInterfaces = std::set<std::unique_ptr<NetworkInterface>>;
+    using NetworkInterfaces = std::vector<NetworkInterface>;
 }
 
 #endif

--- a/include/netifaces/netifaces.hpp
+++ b/include/netifaces/netifaces.hpp
@@ -8,15 +8,12 @@
 #include "provider.hpp"
 
 namespace netifaces {
-    NetworkInterfaces interfaces() {
-        static NetworkInterfaceProvider provider;
-        NetworkInterfaces result;
-        provider.interfaces(std::move(result));
-        return result;
+    inline NetworkInterfaces interfaces() {
+        return NetworkInterfaceProvider::interfaces();
     }
 }
 
-std::string to_string(const netifaces::NetworkProto& proto) {
+inline std::string to_string(const netifaces::NetworkProto& proto) {
     switch(proto) {
         case netifaces::NetworkProto::IPv4:
             return "IPv4";
@@ -27,7 +24,7 @@ std::string to_string(const netifaces::NetworkProto& proto) {
     }
 }
 
-std::ostream& operator<<(std::ostream& os, const netifaces::NetworkProto& proto) {
+inline std::ostream& operator<<(std::ostream& os, const netifaces::NetworkProto& proto) {
     os << to_string(proto);
     return os;
 }

--- a/include/netifaces/provider.hpp
+++ b/include/netifaces/provider.hpp
@@ -2,62 +2,70 @@
 #ifndef NETIFACES_PROVIDER_HPP
 #define NETIFACES_PROVIDER_HPP
 
+#include <unordered_map>
 
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #include <ifaddrs.h>
 
+#include "basic_types.hpp"
+
 namespace netifaces {
-    class NetworkInterfaceProvider {
-        NetworkProto convertToProto(sa_family_t family) {
-            switch(family) {
-                case AF_INET:
-                    return NetworkProto::IPv4;
-                case AF_INET6:
-                    return NetworkProto::IPv6;
-                default:
-                    return NetworkProto::UNKNOWN;
+    namespace NetworkInterfaceProvider {
+        namespace internal {
+            inline NetworkProto convertToProto(sa_family_t family) {
+                switch(family) {
+                    case AF_INET:
+                        return NetworkProto::IPv4;
+                    case AF_INET6:
+                        return NetworkProto::IPv6;
+                    default:
+                        return NetworkProto::UNKNOWN;
+                }
+            }
+
+            inline NetworkAddress convertToAddress(ifaddrs* ifa) {
+                auto proto = convertToProto(ifa->ifa_addr->sa_family);
+
+                if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET) {
+                    char inet_addr[INET_ADDRSTRLEN];
+                    auto sa = reinterpret_cast<sockaddr_in*>(ifa->ifa_addr);
+                    inet_ntop(ifa->ifa_addr->sa_family, &(sa->sin_addr), inet_addr, INET_ADDRSTRLEN);
+                    return NetworkAddress(proto, inet_addr);
+                }
+
+                if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET6) {
+                    char inet_addr[INET6_ADDRSTRLEN];
+                    auto sa = reinterpret_cast<sockaddr_in6*>(ifa->ifa_addr);
+                    inet_ntop(ifa->ifa_addr->sa_family, &(sa->sin6_addr), inet_addr, INET6_ADDRSTRLEN);
+                    return NetworkAddress(proto, inet_addr);
+                }
+                return NetworkAddress(proto, "UNKNOWN_ADDRESS");
             }
         }
 
-        NetworkAddress convertToAddress(ifaddrs* ifa) {
-            auto proto = convertToProto(ifa->ifa_addr->sa_family);
-            
-            if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET) {
-                char inet_addr[INET_ADDRSTRLEN];
-                auto sa = reinterpret_cast<sockaddr_in*>(ifa->ifa_addr);
-                inet_ntop(ifa->ifa_addr->sa_family, &(sa->sin_addr), inet_addr, INET_ADDRSTRLEN);
-                return NetworkAddress(proto, inet_addr);
-            }
-
-            if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET6) {
-                char inet_addr[INET6_ADDRSTRLEN];
-                auto sa = reinterpret_cast<sockaddr_in6*>(ifa->ifa_addr);
-                inet_ntop(ifa->ifa_addr->sa_family, &(sa->sin6_addr), inet_addr, INET6_ADDRSTRLEN);
-                return NetworkAddress(proto, inet_addr);
-            }
-            return NetworkAddress(proto, "UNKNOWN_ADDRESS");
-        }
-
-    public:
-        void interfaces(NetworkInterfaces&& ifaces) {
-            std::unordered_map<std::string, std::unique_ptr<NetworkInterface>> dedup;
+        inline NetworkInterfaces interfaces() {
+            std::unordered_map<std::string, NetworkInterface> dedup;
             ifaddrs* ifaddr;
             getifaddrs (&ifaddr);
             for (ifaddrs* ifa = ifaddr; ifa; ifa = ifa->ifa_next) {
                 auto iface = dedup.find(ifa->ifa_name);
                 if (iface == dedup.end()) {
-                    dedup[ifa->ifa_name] = std::make_unique<NetworkInterface>(ifa->ifa_name);
+                    auto inserted = dedup.emplace(ifa->ifa_name, ifa->ifa_name);
+                    inserted.first->second.add(internal::convertToAddress(ifa));
+                    continue;
                 }
-                dedup[ifa->ifa_name]->mutable_addrs().emplace_back(convertToAddress(ifa));
+                iface->second.add(internal::convertToAddress(ifa));
             }
             freeifaddrs(ifaddr);
 
+            NetworkInterfaces ifaces;
             for (auto& kv : dedup) {
-                ifaces.insert(std::move(kv.second));
+                ifaces.push_back(std::move(kv.second));
             }
+            return ifaces;
         }
-    };
+    }
 }
 
 #endif


### PR DESCRIPTION
Most of the changes in this patch are from clang-tidy, namely:
- Marking functions implemented in header files 'inline'
- Pass by reference rather than by value
- Marking functions that do not access any class members as 'static'

However, I noticed after the changes above a couple of low-hanging
fruits, so I took the liberty and did the following:
- Remove the class that has all static members, and make the functions
free.
- Reduce allocations by removing unique_ptrs
- Return a vector rather than a set
- Avoid multiple look-ups in the dedup map
- Make getter functions return by const&